### PR TITLE
allow triggering filter block when eof for initial state of input stream

### DIFF
--- a/lib/filter_io.rb
+++ b/lib/filter_io.rb
@@ -103,7 +103,8 @@ class FilterIO
     return '' if length == 0
 
     # fill the buffer up to the fill level (or whole input if length is nil)
-    while !source_eof? && (length.nil? || length > @buffer.bytesize)
+    while (!source_eof? || !@did_first_read) && (length.nil? || length > @buffer.bytesize)
+      @did_first_read = true
       buffer_data @options[:block_size] || length
     end
 
@@ -310,7 +311,7 @@ class FilterIO
       @source_pos += data.bytesize
       data.force_encoding(external_encoding)
     else
-      return
+      data = ""
     end
 
     initial_data_size = data.bytesize

--- a/spec/filter_io_spec.rb
+++ b/spec/filter_io_spec.rb
@@ -917,4 +917,27 @@ describe FilterIO do
 
     expect(rows).to eq [%w[FOO BAR], %w[BAZ]]
   end
+
+  it 'calls block when stream empty' do
+    io = FilterIO.new StringIO.new('') do |data, state|
+      out = state.bof? ? 'start' : ''
+      out << data.upcase
+      out << 'end' if state.eof?
+    end
+    expect(io.read).to eq 'startend'
+
+    # multiple reads from empty stream should only trigger block once
+    expect(io.read).to eq ""
+  end
+
+  it 'no longer calls block once the stream is eof' do
+    io = FilterIO.new StringIO.new('foo') do |data, state|
+      out = state.bof? ? 'start' : ''
+      out << data.upcase
+      out << 'end' if state.eof?
+    end
+    expect(io.read).to eq 'startFOOend'
+    expect(io.read).to eq ""
+  end
+
 end


### PR DESCRIPTION
Addresses #7, but not sure it is the right solution.

Note that this does break backwards compatibility somewhat if users assume that the block only gets called with data (i.e. see the change of line 418 of filter_io_spec.rb)
